### PR TITLE
chore: Added jobType for export job to restrict asset status change COMPLETED

### DIFF
--- a/src/constants/artifact.js
+++ b/src/constants/artifact.js
@@ -12,7 +12,15 @@ const ArtifactStatus = {
   FAILED: 'failed'
 };
 
+const JobType = {
+  EXPORT: 'export',
+  IMPORT: 'import',
+  PROMOTE_EXPORT: 'promote_export',
+  PROMOTE_IMPORT: 'promote_import'
+};
+
 module.exports = {
   Assets,
-  ArtifactStatus
+  ArtifactStatus,
+  JobType
 };

--- a/src/core/elements/getElements.js
+++ b/src/core/elements/getElements.js
@@ -39,7 +39,6 @@ const downloadElements = async (elements, query, jobId, processId, isPrivate, jo
         assetName: element.key,
         assetStatus: equals(jobType, JobType.PROMOTE_EXPORT) ? ArtifactStatus.INPROGRESS : ArtifactStatus.COMPLETED,
         metadata: elementMetadata,
-        jobType
       });
 
       return !isNilOrEmpty(exportedElement) ? exportedElement : {};

--- a/src/core/getDataToExport.js
+++ b/src/core/getDataToExport.js
@@ -1,10 +1,10 @@
 'use strict';
 const {type, curry} = require('ramda');
 
-module.exports = curry(async (getData, objectName, jobId, processId) => {
+module.exports = curry(async (getData, objectName, jobId, processId, jobType) => {
   try {
     if (objectName !== undefined && type(objectName) !== 'Function') {
-      return await getData(objectName, jobId, processId);
+      return await getData(objectName, jobId, processId, jobType);
     } else {
       return await getData();
     }

--- a/src/core/saveTo.js
+++ b/src/core/saveTo.js
@@ -1,5 +1,5 @@
 'use strict';
-const { converge, pipe, pipeP, prop, cond, isNil, not } = require('ramda');
+const {converge, pipe, pipeP, prop, cond, isNil, not} = require('ramda');
 const saveTo = (getData, save, property) =>
   converge(save, [
     pipe(prop('options'), prop(property)),
@@ -8,6 +8,7 @@ const saveTo = (getData, save, property) =>
         pipe(prop('options'), prop('name')),
         pipe(prop('options'), prop('jobId')),
         pipe(prop('options'), prop('processId')),
+        pipe(prop('options'), prop('jobType')),
       ]),
     ),
   ]);

--- a/src/core/vdrs/download/getVdrs.js
+++ b/src/core/vdrs/download/getVdrs.js
@@ -3,7 +3,7 @@ const getVdrNames = require('./getVdrNames');
 const exportVdrs = require('./exportVdrs');
 const applyQuotes = require('../../../util/quoteString');
 
-module.exports = async (vdrName, jobId, processId) => {
+module.exports = async (vdrName, jobId, processId, jobType) => {
   try {
     // From CLI - User can pass comma seperated string of vdrs name
     // From Service - It will be in Array of objects containing vdr name
@@ -17,7 +17,7 @@ module.exports = async (vdrName, jobId, processId) => {
       param = {where: 'objectName in (' + applyQuotes(join(',', vdrNames)) + ')'};
     }
     vdrNames = await getVdrNames(param);
-    const exportData = await exportVdrs(vdrNames, vdrName, jobId, processId);
+    const exportData = await exportVdrs(vdrNames, vdrName, jobId, processId, jobType);
     return exportData;
   } catch (error) {
     throw error;


### PR DESCRIPTION
## Conventional Commit
chore: Promote job artifact's status update ([ENG-1542](https://cloudelements.atlassian.net/browse/ENG-1542))
In case of promote export job, restrict artifact's status from getting changed to COMPLETED. It should remain in INPROGRESS even if it is successfully downloaded.

**Linked PR:** https://github.com/cloud-elements/doctor-service/pull/150