### PR TITLE
fix: Reduce the file size of artifacts that are saved to disk (ENG-3692)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudelements/doctor-core",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "The Core functionality of Doctor - The Cloud Elements Asset Management Tool",
   "main": "index.js",
   "scripts": {

--- a/src/core/elements/getElements.js
+++ b/src/core/elements/getElements.js
@@ -16,7 +16,7 @@ const clearNull = pipe(reject(isNil));
 
 const downloadElements = async (elements, query, jobId, processId, isPrivate, jobType, account) => {
   logDebug('Initiating the download process for elements', jobId);
-  const downloadPromises = await elements.map(async element => {
+  const downloadPromises = elements.map(async element => {
     const elementMetadata = JSON.stringify({private: isPrivate});
     try {
       if (isJobCancelled(jobId)) {
@@ -97,14 +97,14 @@ module.exports = async (account, elementKeys, jobId, processId, jobType) => {
         ? []
         : extendedElementsExport
       : isNilOrEmpty(extendedElementsExport)
-      ? privateElementsExport
-      : privateElementsExport.concat(extendedElementsExport);
+        ? privateElementsExport
+        : privateElementsExport.concat(extendedElementsExport);
 
     const newlyCreatedElements =
       !isNilOrEmpty(elementKeys) && Array.isArray(elementKeys)
         ? elementKeys.filter(
-            elementKey => elementKey.private && !privateElements.some(element => equals(element.key, elementKey.key)),
-          )
+          elementKey => elementKey.private && !privateElements.some(element => equals(element.key, elementKey.key)),
+        )
         : [];
 
     newlyCreatedElements.forEach(element =>

--- a/src/core/elements/saveElementsToDir.js
+++ b/src/core/elements/saveElementsToDir.js
@@ -8,7 +8,7 @@ const getResourceName = require('../../utils/getResourceName');
 const isNilOrEmpty = val => isNil(val) || isEmpty(val);
 
 module.exports = async (dir, data) => {
-  const elements = await data;
+  const elements = data;
   if (!existsSync(dir)) {
     fsExtra.ensureDirSync(dir);
   }

--- a/src/core/elements/saveElementsToDir.js
+++ b/src/core/elements/saveElementsToDir.js
@@ -2,7 +2,6 @@
 const {existsSync} = require('fs');
 const fsExtra = require('fs-extra');
 const {forEach, dissoc, map, omit, pipe, tap, gt, propOr, pluck, countBy, identity, isNil, isEmpty} = require('ramda');
-const sortobject = require('deep-sort-object');
 const {toDirectoryName} = require('../../utils/regex');
 const getResourceName = require('../../utils/getResourceName');
 
@@ -22,7 +21,7 @@ module.exports = async (dir, data) => {
   forEach(element => {
     const elementFolder =
       gt(Number(propOr(1, element.name)(allElementsNameCount)), 1) &&
-      (isNilOrEmpty(element.private) ? element.extended : !element.private)
+        (isNilOrEmpty(element.private) ? element.extended : !element.private)
         ? `${dir}/${toDirectoryName(element.name)}_extended`
         : `${dir}/${toDirectoryName(element.name)}`;
 
@@ -68,6 +67,6 @@ module.exports = async (dir, data) => {
         return omit(['createdDate', 'updatedDate'], resource);
       })(element.resources).sort((a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method));
     }
-    fsExtra.outputFileSync(`${elementFolder}/element.json`, JSON.stringify(sortobject(element), null, 4), 'utf8');
+    fsExtra.outputFileSync(`${elementFolder}/element.json`, JSON.stringify(element), 'utf8');
   })(elements);
 };

--- a/src/core/formulas/saveFormulasToDir.js
+++ b/src/core/formulas/saveFormulasToDir.js
@@ -51,7 +51,7 @@ const cleanFormula = formula => {
 
 module.exports = async (dir, data) => {
   try {
-    let formulas = await data;
+    let formulas = data;
     formulas = map(cleanFormula)(formulas);
     if (!existsSync(dir)) {
       fsExtra.ensureDirSync(dir);

--- a/src/core/formulas/saveFormulasToDir.js
+++ b/src/core/formulas/saveFormulasToDir.js
@@ -2,7 +2,6 @@
 const {existsSync} = require('fs');
 const fsExtra = require('fs-extra');
 const {forEach, map, dissoc, omit, when, dissocPath, pipe, tap} = require('ramda');
-const sortobject = require('deep-sort-object');
 const {toDirectoryName} = require('../../utils/regex');
 const {logError} = require('../../utils/logger');
 
@@ -75,7 +74,7 @@ module.exports = async (dir, data) => {
             ),
           ),
         )(formula.steps);
-        fsExtra.outputFileSync(`${formulaFolder}/formula.json`, JSON.stringify(sortobject(formula), null, 4), 'utf8');
+        fsExtra.outputFileSync(`${formulaFolder}/formula.json`, JSON.stringify(formula), 'utf8');
       } catch (error) {
         logError(`Failed to save data into formula file: ${dir}`);
         throw error;

--- a/src/core/vdrs/saveVdrsToDir.js
+++ b/src/core/vdrs/saveVdrsToDir.js
@@ -63,7 +63,7 @@ const moveOldFilestoBackup = async dirPath => {
  */
 const saveVdrsToDirNew = async (dir, data) => {
   try {
-    const vdrs = await data;
+    const vdrs = data;
     createDirIfNotExist(dir);
     moveOldFilestoBackup(dir);
     forEachObjIndexed((vdrNameObject, vdrName) => {
@@ -123,7 +123,7 @@ const saveVdrsToDirNew = async (dir, data) => {
  */
 const saveVdrsToDirOld = async (dir, data) => {
   try {
-    const vdrs = await data;
+    const vdrs = data;
     createDirIfNotExist(dir);
     const definitionDir = `${dir}/objectDefinitions`;
     createDirIfNotExist(definitionDir);

--- a/src/core/vdrs/saveVdrsToDir.js
+++ b/src/core/vdrs/saveVdrsToDir.js
@@ -4,7 +4,6 @@
 const {existsSync, renameSync, readdir, lstatSync} = require('fs');
 const fsExtra = require('fs-extra');
 const {forEachObjIndexed, dissoc, isNil, isEmpty} = require('ramda');
-const sortobject = require('deep-sort-object');
 const {join} = require('path');
 const {promisify} = require('util');
 const {replaceall} = require('replaceall');
@@ -70,7 +69,7 @@ const saveVdrsToDirNew = async (dir, data) => {
     forEachObjIndexed((vdrNameObject, vdrName) => {
       const vdrDir = `${dir}/${vdrName}`;
       createDirIfNotExist(vdrDir);
-      fsExtra.outputFileSync(`${vdrDir}/${vdrName}.json`, JSON.stringify(sortobject(vdrNameObject), null, 4), 'utf8');
+      fsExtra.outputFileSync(`${vdrDir}/${vdrName}.json`, JSON.stringify(vdrNameObject), 'utf8');
       // save defintion
       const {definition} = vdrNameObject;
       const definitionDir = `${vdrDir}/definition`;
@@ -81,7 +80,7 @@ const saveVdrsToDirNew = async (dir, data) => {
           : [];
       fsExtra.outputFileSync(
         `${definitionDir}/objectDefinition.json`,
-        JSON.stringify(sortobject(definition), null, 4),
+        JSON.stringify(definition),
         'utf8',
       );
       // save transformation
@@ -102,7 +101,7 @@ const saveVdrsToDirNew = async (dir, data) => {
         }
         fsExtra.outputFileSync(
           `${elementTransformtaionDir}/transformation.json`,
-          JSON.stringify(sortobject(elementTransformtaion), null, 4),
+          JSON.stringify(elementTransformtaion),
           'utf8',
         );
       })(transformations);
@@ -140,7 +139,7 @@ const saveVdrsToDirOld = async (dir, data) => {
           : [];
       fsExtra.outputFileSync(
         `${objectDirName}/objectDefinition.json`,
-        JSON.stringify(sortobject(dissoc('id', vdr.definition)), null, 4),
+        JSON.stringify(dissoc('id', vdr.definition)),
         'utf8',
       );
       // save transformation
@@ -159,7 +158,7 @@ const saveVdrsToDirOld = async (dir, data) => {
         }
         fsExtra.outputFileSync(
           `${elementTransformtaionByVdrNameDir}/transformation.json`,
-          JSON.stringify(sortobject(elementTransformation), null, 4),
+          JSON.stringify(elementTransformation),
           'utf8',
         );
       })(vdr.transformation);

--- a/src/utils/saveToFile.js
+++ b/src/utils/saveToFile.js
@@ -5,7 +5,7 @@ const {logDebug} = require('./logger');
 
 module.exports = curry(async (fileName, data) => {
   try {
-    fsExtra.outputFileSync(fileName, JSON.stringify(await data, null, 2), 'utf8');
+    fsExtra.outputFileSync(fileName, JSON.stringify(await data), 'utf8');
   } catch (error) {
     logDebug(`Failed to save data into file: ${fileName}`);
     throw error;


### PR DESCRIPTION
## Conventional Commit
fix: Reduce the file size of each artifact that will be saved to disk so that the compression happens a bit more faster (as part of [ENG-3692](https://cloudelements.atlassian.net/browse/ENG-3692))

#### File size of Netsuite element that was being saved to disk:
Before: 46 MB
After: 16 MB
This would help make the compression faster as the file read becomes a bit faster